### PR TITLE
Finished ColorsTableVC and ColorsDetailVC to Display Color on both Views

### DIFF
--- a/RandomColors/RandomColors.xcodeproj/project.pbxproj
+++ b/RandomColors/RandomColors.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		87089FA82B62E92C0052CBF7 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 87089FA62B62E92C0052CBF7 /* LaunchScreen.storyboard */; };
 		87089FB22B62EAD70052CBF7 /* ColorsTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87089FB12B62EAD70052CBF7 /* ColorsTableVC.swift */; };
 		87089FB42B62EC410052CBF7 /* ColorsDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87089FB32B62EC410052CBF7 /* ColorsDetailVC.swift */; };
+		87089FB62B62FB950052CBF7 /* UIColor+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87089FB52B62FB950052CBF7 /* UIColor+Ext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		87089FA92B62E92C0052CBF7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		87089FB12B62EAD70052CBF7 /* ColorsTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsTableVC.swift; sourceTree = "<group>"; };
 		87089FB32B62EC410052CBF7 /* ColorsDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsDetailVC.swift; sourceTree = "<group>"; };
+		87089FB52B62FB950052CBF7 /* UIColor+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Ext.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				87089F9D2B62E92B0052CBF7 /* SceneDelegate.swift */,
 				87089FB12B62EAD70052CBF7 /* ColorsTableVC.swift */,
 				87089FB32B62EC410052CBF7 /* ColorsDetailVC.swift */,
+				87089FB52B62FB950052CBF7 /* UIColor+Ext.swift */,
 				87089FA12B62E92B0052CBF7 /* Main.storyboard */,
 				87089FA42B62E92C0052CBF7 /* Assets.xcassets */,
 				87089FA62B62E92C0052CBF7 /* LaunchScreen.storyboard */,
@@ -143,6 +146,7 @@
 			files = (
 				87089FB22B62EAD70052CBF7 /* ColorsTableVC.swift in Sources */,
 				87089FB42B62EC410052CBF7 /* ColorsDetailVC.swift in Sources */,
+				87089FB62B62FB950052CBF7 /* UIColor+Ext.swift in Sources */,
 				87089F9C2B62E92B0052CBF7 /* AppDelegate.swift in Sources */,
 				87089F9E2B62E92B0052CBF7 /* SceneDelegate.swift in Sources */,
 			);

--- a/RandomColors/RandomColors/Base.lproj/Main.storyboard
+++ b/RandomColors/RandomColors/Base.lproj/Main.storyboard
@@ -16,20 +16,32 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p3P-MO-ogc">
-                                <rect key="frame" x="159" y="408.66666666666669" width="75" height="35"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="KS2-OT-INM">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ColorCell" id="ybC-Db-f9V">
+                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ybC-Db-f9V" id="9ka-mp-0y0">
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                                 <connections>
-                                    <action selector="tempButtonTapped:" destination="0Dv-6a-clw" eventType="touchUpInside" id="YIW-Ng-00g"/>
+                                    <outlet property="dataSource" destination="0Dv-6a-clw" id="Eo7-Ud-PTJ"/>
+                                    <outlet property="delegate" destination="0Dv-6a-clw" id="UZd-XM-Stf"/>
                                 </connections>
-                            </button>
+                            </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="dtK-zi-TLN"/>
-                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="p3P-MO-ogc" firstAttribute="centerX" secondItem="E1V-Vp-Avo" secondAttribute="centerX" id="IAU-iu-3Cm"/>
-                            <constraint firstItem="p3P-MO-ogc" firstAttribute="centerY" secondItem="E1V-Vp-Avo" secondAttribute="centerY" id="t2y-pY-JO2"/>
+                            <constraint firstItem="KS2-OT-INM" firstAttribute="leading" secondItem="E1V-Vp-Avo" secondAttribute="leading" id="Qeo-2B-a2H"/>
+                            <constraint firstAttribute="trailing" secondItem="KS2-OT-INM" secondAttribute="trailing" id="fP3-YA-cjr"/>
+                            <constraint firstItem="KS2-OT-INM" firstAttribute="top" secondItem="E1V-Vp-Avo" secondAttribute="top" id="jWt-gP-wnc"/>
+                            <constraint firstAttribute="bottom" secondItem="KS2-OT-INM" secondAttribute="bottom" id="scB-za-HQw"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Colors" id="RAD-tl-Z8R"/>
@@ -79,9 +91,6 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/RandomColors/RandomColors/ColorsDetailVC.swift
+++ b/RandomColors/RandomColors/ColorsDetailVC.swift
@@ -8,9 +8,13 @@
 import UIKit
 
 class ColorsDetailVC: UIViewController {
+    
+    var color: UIColor?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        view.backgroundColor = color ?? UIColor.blue
 
         // Do any additional setup after loading the view.
     }

--- a/RandomColors/RandomColors/ColorsTableVC.swift
+++ b/RandomColors/RandomColors/ColorsTableVC.swift
@@ -8,27 +8,68 @@
 import UIKit
 
 class ColorsTableVC: UIViewController {
+    
+    var colors: [UIColor] = []
+    
+    enum Cells {
+        static let colorCell = "ColorCell"
+    }
+    
+    enum Segues {
+        static let toDetail = "ToColorsDetailVC"
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        addRandomColors()
     }
     
-    // This was dragged from the storyboard into this file (automatically created function)
-    // Now, whenever the button is tapped in this view, the following code will execute
-    @IBAction func tempButtonTapped(_ sender: UIButton) {
-        performSegue(withIdentifier: "ToColorsDetailVC", sender: nil)
+    // Create 50 random colors and add them to the colors array for display
+    func addRandomColors() {
+        for _ in 0..<50 {
+            colors.append(UIColor.random())
+        }
     }
     
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        let destVC = segue.destination as! ColorsDetailVC
+        destVC.color = sender as? UIColor
     }
-    */
 
+}
+
+// Make this extension solely for better code organization
+// This will now only handle code for the table view
+extension ColorsTableVC: UITableViewDelegate, UITableViewDataSource {
+    
+    // DataSource Method:
+    // Determines how many rows to show
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return colors.count
+    }
+    
+    // Delegate Method: (Wait for specific action to occur before executing)
+    // Everytime cell appears on a screen, this funciton will be called (customize cells here)
+    // When a cell "leaves" the view of the screen it is reused and it's content is refigured for the next cell that is populated in the view
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        // Ensures the cell isn't nil before populating the VC
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: Cells.colorCell) else {
+            return UITableViewCell()
+        }
+        
+        // Send the associated color for the row number of the table that is being displayed
+        let color = colors[indexPath.row]
+        cell.backgroundColor = color
+        
+        return cell
+    }
+    
+    // Row selected, segue to ColorsDetailVC
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let color = colors[indexPath.row]
+        performSegue(withIdentifier: Segues.toDetail, sender: color)
+    }
 }

--- a/RandomColors/RandomColors/UIColor+Ext.swift
+++ b/RandomColors/RandomColors/UIColor+Ext.swift
@@ -1,0 +1,20 @@
+//
+//  UIColor+Ext.swift
+//  RandomColors
+//
+//  Created by Marco Capraro on 1/25/24.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    // Creates a random UIColor
+    static func random() -> UIColor {
+        let randomColor = UIColor(red: CGFloat.random(in: 0...1),
+                                  green: CGFloat.random(in: 0...1),
+                                  blue: CGFloat.random(in: 0...1),
+                                  alpha: 1)
+        return randomColor
+    }
+}


### PR DESCRIPTION
Added table view code to ColorsTableVC. This included creating a color array of size 50 that is populated with random UIColors that are then used to create reusable cells that are shown on the screen of the app. Additionally added the logic to pass along the color data of each cell to the ColorsDetailVC such that it can then display that color as the background color on that view once the cell is selected from the ColorsTableVC.